### PR TITLE
Add contributor to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2010 Parker Samp
 Copyright (c) 2014 Peter Reid
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Added accreditation for Parker Samp, as they wrote the original script that linuxmotd is a modification of.

While the lack of license at the original source does not make this a legal requirement, it is still common courtesy to credit the original source of work.

The original script can be found at the following URL: http://parkersamp.com/2010/10/howto-creating-a-dynamic-motd-in-linux/
